### PR TITLE
Update tutorial

### DIFF
--- a/docs/cmd.md
+++ b/docs/cmd.md
@@ -5,7 +5,7 @@ Usage:
   Scaffolder [OPTION...] INPUT OUTPUT PARAMETERS
 
   -h, --help                    Print help
-  -i, --input INPUT             Input file (STL/PLY/OFF/OBJ/VMI)
+  -i, --input INPUT             Input file (STL/OFF/OBJ)
   -o, --output OUTPUT           Output filename with extension
                                 stl,ply,obj,off,ctm
       --params PARAMETERS       Combined parameters list:

--- a/docs/cmd.md
+++ b/docs/cmd.md
@@ -24,7 +24,7 @@ Usage:
       --grid_offset INT (0..60000)
                                 [default:3]
   -m, --microstructure          Analysis microstructure with Slice contour
-                                technique ( [default: false]
+                                technique [default: false]
       --export_microstructure   Analysis microstructure and export the 2D
                                 contours (for debugging) [default: false]
       --export_jpeg [X|Y|Z],INT

--- a/docs/jupyter/TPMS.ipynb
+++ b/docs/jupyter/TPMS.ipynb
@@ -20,22 +20,18 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "!git clone https://github.com/fogleman/sdf\n",
-        "!pip install PyScaffolder"
-      ],
+      "execution_count": null,
       "metadata": {
-        "id": "k1QuoXni0wXJ",
-        "outputId": "d8ced732-dea3-42b9-dddb-b5b25d49716a",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "k1QuoXni0wXJ",
+        "outputId": "d8ced732-dea3-42b9-dddb-b5b25d49716a"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Cloning into 'sdf'...\n",
             "remote: Enumerating objects: 861, done.\u001b[K\n",
@@ -52,10 +48,17 @@
             "Successfully installed PyScaffolder-1.5.2\n"
           ]
         }
+      ],
+      "source": [
+        "!git clone https://github.com/fogleman/sdf\n",
+        "!pip install PyScaffolder"
       ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "av6a2Jwm69VM"
+      },
       "source": [
         "## The implicit function of TPMS\n",
         "\n",
@@ -80,25 +83,22 @@
         "The wrapper `@sdf3` will provide gyroid function with 3D points (`p`)).\n",
         "Then these (x,y, z) points will multiply by `w` and calculate the iso-level of gyroid by vectorized numpy function. \n",
         "\n"
-      ],
-      "metadata": {
-        "id": "av6a2Jwm69VM"
-      }
+      ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "pm_CwCcV0Wte",
-        "outputId": "f7626e5a-1a15-4f6b-bc67-ea44c344ace0",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "pm_CwCcV0Wte",
+        "outputId": "f7626e5a-1a15-4f6b-bc67-ea44c344ace0"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "/content/sdf\n",
             "The autoreload extension is already loaded. To reload it, use:\n",
@@ -152,16 +152,16 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "XKPr5MOw0Wtg",
-        "outputId": "97259e25-657a-42b7-a5ce-0f35c911b19a",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "XKPr5MOw0Wtg",
+        "outputId": "97259e25-657a-42b7-a5ce-0f35c911b19a"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "min -0.543491, -0.543491, -0.543491\n",
             "max 0.543491, 0.543491, 0.543491\n",
@@ -195,16 +195,16 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "jGZ_RNvG0Wtg",
-        "outputId": "d180c95a-edfb-41e2-9a44-3f9c671b1a46",
         "colab": {
           "base_uri": "https://localhost:8080/"
-        }
+        },
+        "id": "jGZ_RNvG0Wtg",
+        "outputId": "d180c95a-edfb-41e2-9a44-3f9c671b1a46"
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "min -0.543491, -0.543491, -0.543491\n",
             "max 0.543491, 0.543491, 0.543491\n",
@@ -218,7 +218,7 @@
         "# Generate with PyScaffolder.marching_cubes\n",
         "import PyScaffolder\n",
         "def marching_cubes(f, step=0.01, bounds=None, verbose=True, clean=True):\n",
-        "    from sdf.mesh import _estimate_bounds, _cartesian_product\n",
+        "    from sdf.core import _estimate_bounds, _cartesian_product\n",
         "    import time\n",
         "\n",
         "    if not bounds:\n",
@@ -263,17 +263,22 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "nS1Cct6M9Mzz"
+      },
       "source": [
         "## Generate the other TPMS\n",
         "\n",
         "The following codes will generate SchwarzP and BCC structure. The output files can be found at `/content/sdf/` "
-      ],
-      "metadata": {
-        "id": "nS1Cct6M9Mzz"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "9LFfSAZR9Uor"
+      },
+      "outputs": [],
       "source": [
         "@sdf3\n",
         "def schwarz_p(w = 3.14159, t=0):\n",
@@ -290,20 +295,11 @@
         "        x, y, z = (q[:, i] for i in range(3))\n",
         "        return np.cos(x) + np.cos(y) + np.cos(z) -2*(np.cos(x/2)*np.cos(y/2) + np.cos(y/2)*np.cos(z/2) + np.cos(z/2)*np.cos(x/2))\n",
         "    return f"
-      ],
-      "metadata": {
-        "id": "9LFfSAZR9Uor"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "f2 = box(1) & schwarz_p(w=12)\n",
-        "points = marching_cubes(f2, step=0.01, verbose=True, clean=True)\n",
-        "write_binary_stl('schwarz_p.stl', points)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -311,11 +307,10 @@
         "id": "TzAD5XK59ZRC",
         "outputId": "8919bf3e-7b86-4f24-9592-bb1b05082029"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "min -0.543491, -0.543491, -0.543491\n",
             "max 0.543491, 0.543491, 0.543491\n",
@@ -324,15 +319,16 @@
             "59388 triangles in 0.45409 seconds\n"
           ]
         }
+      ],
+      "source": [
+        "f2 = box(1) & schwarz_p(w=12)\n",
+        "points = marching_cubes(f2, step=0.01, verbose=True, clean=True)\n",
+        "write_binary_stl('schwarz_p.stl', points)"
       ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "f3 = box(1) & bcc(w=12)\n",
-        "points = marching_cubes(f3, step=0.01, verbose=True, clean=True)\n",
-        "write_binary_stl('bcc.stl', points)"
-      ],
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -340,11 +336,10 @@
         "id": "IZc583ld9xRw",
         "outputId": "6fd246df-d342-492f-dfcd-41adb8154adb"
       },
-      "execution_count": null,
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "min -0.543491, -0.543491, -0.543491\n",
             "max 0.543491, 0.543491, 0.543491\n",
@@ -353,10 +348,18 @@
             "49112 triangles in 0.377038 seconds\n"
           ]
         }
+      ],
+      "source": [
+        "f3 = box(1) & bcc(w=12)\n",
+        "points = marching_cubes(f3, step=0.01, verbose=True, clean=True)\n",
+        "write_binary_stl('bcc.stl', points)"
       ]
     }
   ],
   "metadata": {
+    "colab": {
+      "provenance": []
+    },
     "interpreter": {
       "hash": "338d088b7365852483cbb7f745c4a9fbf18ad887a6ae80fcf58992043df108c7"
     },
@@ -376,10 +379,7 @@
       "pygments_lexer": "ipython3",
       "version": "3.9.10"
     },
-    "orig_nbformat": 4,
-    "colab": {
-      "provenance": []
-    }
+    "orig_nbformat": 4
   },
   "nbformat": 4,
   "nbformat_minor": 0

--- a/docs/jupyter/test_1.ipynb
+++ b/docs/jupyter/test_1.ipynb
@@ -2,86 +2,82 @@
     "cells": [
         {
             "cell_type": "markdown",
+            "metadata": {},
             "source": [
-                "# TPMS with SDF and PyScaffolder\r\n",
-                "Author: [Jirawat Iamsamang](https://github.com/nodtem66)  \r\n",
-                "\r\n",
-                "## Abstract\r\n",
-                "SDF provides a class for discretizing and visualizing any implicit surfaces. The basic topologies (e.g. sphere, box) are already defined.\r\n",
-                "This notebook shows how to utilize this library to generate gyroid surface.\r\n",
-                "\r\n",
-                "## Installation\r\n",
-                "* Currently, SDF is not in PyPI. So the [github of SDF](https://github.com/fogleman/sdf) needs to clone into local computer. See [Installation](https://github.com/fogleman/sdf#installation)\r\n",
-                "* By contrast, PyScaffolder was installed by `pip install PyScaffolder`\r\n",
-                "\r\n",
-                "## Gyroid\r\n",
-                "The gyroid function is defined as shown in a following cell.  \r\n",
-                "The wrapper `@sdf3` will provide gyroid function with 3D points (`p`)).\r\n",
+                "# TPMS with SDF and PyScaffolder\n",
+                "Author: [Jirawat Iamsamang](https://github.com/nodtem66)  \n",
+                "\n",
+                "## Abstract\n",
+                "SDF provides a class for discretizing and visualizing any implicit surfaces. The basic topologies (e.g. sphere, box) are already defined.\n",
+                "This notebook shows how to utilize this library to generate gyroid surface.\n",
+                "\n",
+                "## Installation\n",
+                "* Currently, SDF is not in PyPI. So the [github of SDF](https://github.com/fogleman/sdf) needs to clone into local computer. See [Installation](https://github.com/fogleman/sdf#installation)\n",
+                "* By contrast, PyScaffolder was installed by `pip install PyScaffolder`\n",
+                "\n",
+                "## Gyroid\n",
+                "The gyroid function is defined as shown in a following cell.  \n",
+                "The wrapper `@sdf3` will provide gyroid function with 3D points (`p`)).\n",
                 "Then these (x,y, z) points will multiply by `w` and calculate the iso-level of gyroid by vectorized numpy function. "
-            ],
-            "metadata": {}
+            ]
         },
         {
             "cell_type": "code",
             "execution_count": 51,
-            "source": [
-                "%load_ext autoreload\r\n",
-                "%autoreload 2\r\n",
-                "\r\n",
-                "import numpy as np\r\n",
-                "import PyScaffolder\r\n",
-                "from sdf import *\r\n",
-                "\r\n",
-                "@sdf3\r\n",
-                "def gyroid(w = 3.14159, t=0):\r\n",
-                "    def f(p):\r\n",
-                "        q = w*p\r\n",
-                "        x, y, z = (q[:, i] for i in range(3))\r\n",
-                "        return np.cos(x)*np.sin(y) + np.cos(y)*np.sin(z) + np.cos(z)*np.sin(x) - t\r\n",
-                "    return f"
-            ],
+            "metadata": {},
             "outputs": [
                 {
-                    "output_type": "stream",
                     "name": "stdout",
+                    "output_type": "stream",
                     "text": [
                         "The autoreload extension is already loaded. To reload it, use:\n",
                         "  %reload_ext autoreload\n"
                     ]
                 }
             ],
-            "metadata": {}
+            "source": [
+                "%load_ext autoreload\n",
+                "%autoreload 2\n",
+                "\n",
+                "import numpy as np\n",
+                "import PyScaffolder\n",
+                "from sdf import *\n",
+                "\n",
+                "@sdf3\n",
+                "def gyroid(w = 3.14159, t=0):\n",
+                "    def f(p):\n",
+                "        q = w*p\n",
+                "        x, y, z = (q[:, i] for i in range(3))\n",
+                "        return np.cos(x)*np.sin(y) + np.cos(y)*np.sin(z) + np.cos(z)*np.sin(x) - t\n",
+                "    return f"
+            ]
         },
         {
             "cell_type": "markdown",
+            "metadata": {},
             "source": [
-                "## Generate with SKimage\r\n",
-                "SDF used `marching_cubes` from `skimage.measure` with a `ThreadPool`, so it's super fast to construct the 3D mesh.\r\n",
+                "## Generate with SKimage\n",
+                "SDF used `marching_cubes` from `skimage.measure` with a `ThreadPool`, so it's super fast to construct the 3D mesh.\n",
                 "Let's create a constructing function that intersect a gyroid and a unit box."
-            ],
-            "metadata": {}
+            ]
         },
         {
             "cell_type": "code",
             "execution_count": 52,
+            "metadata": {},
+            "outputs": [],
             "source": [
                 "f = box(1) & gyroid(w=12)"
-            ],
-            "outputs": [],
-            "metadata": {}
+            ]
         },
         {
             "cell_type": "code",
             "execution_count": 53,
-            "source": [
-                "# Generate with skimage.measure.marching_cubes\r\n",
-                "points = f.generate(step=0.01, verbose=True)\r\n",
-                "write_binary_stl('out_1.stl', points)"
-            ],
+            "metadata": {},
             "outputs": [
                 {
-                    "output_type": "stream",
                     "name": "stdout",
+                    "output_type": "stream",
                     "text": [
                         "min -0.565721, -0.565721, -0.565721\n",
                         "max 0.565722, 0.565722, 0.565722\n",
@@ -93,91 +89,95 @@
                     ]
                 }
             ],
-            "metadata": {}
+            "source": [
+                "# Generate with skimage.measure.marching_cubes\n",
+                "points = f.generate(step=0.01, verbose=True)\n",
+                "write_binary_stl('out_1.stl', points)"
+            ]
         },
         {
             "cell_type": "markdown",
+            "metadata": {},
             "source": [
-                "## Generate with PyScaffolder\r\n",
-                "\r\n",
-                "However, this method occasionally results in incomplete mesh.  \r\n",
+                "## Generate with PyScaffolder\n",
+                "\n",
+                "However, this method occasionally results in incomplete mesh.  \n",
                 "Then let's try `Pyscaffolder.marching_cubes` which implements `dual marching cubes` from [@dominikwodniok/dualmc](https://github.com/dominikwodniok/dualmc)."
-            ],
-            "metadata": {}
+            ]
         },
         {
             "cell_type": "code",
             "execution_count": null,
-            "source": [
-                "# Generate with PyScaffolder.marching_cubes\r\n",
-                "def marching_cubes(f, step=0.01, bounds=None, verbose=True, clean=True):\r\n",
-                "    from sdf.mesh import _estimate_bounds, _cartesian_product\r\n",
-                "    import time\r\n",
-                "\r\n",
-                "    if not bounds:\r\n",
-                "        bounds = _estimate_bounds(f)\r\n",
-                "    (x0, y0, z0), (x1, y1, z1) = bounds\r\n",
-                "    \r\n",
-                "    try:\r\n",
-                "        dx, dy, dz = step\r\n",
-                "    except TypeError:\r\n",
-                "        dx = dy = dz = step\r\n",
-                "    \r\n",
-                "    if verbose:\r\n",
-                "        print('min %g, %g, %g' % (x0, y0, z0))\r\n",
-                "        print('max %g, %g, %g' % (x1, y1, z1))\r\n",
-                "        print('step %g, %g, %g' % (dx, dy, dz))\r\n",
-                "\r\n",
-                "    X = np.arange(x0, x1, dx)\r\n",
-                "    Y = np.arange(y0, y1, dy)\r\n",
-                "    Z = np.arange(z0, z1, dz)\r\n",
-                "\r\n",
-                "    P = _cartesian_product(X, Y, Z)\r\n",
-                "    try:\r\n",
-                "        # Since the PyScaffolder marching_cubes aceept FREP: F(x,y,z) > 0\r\n",
-                "        # Then the negative of implicit function is used\r\n",
-                "        Fxyz = (-f(P))\r\n",
-                "        # Reshape to Fortran array (column-based) due to implementation of dualmc starting from z axis to x\r\n",
-                "        Fxyz = Fxyz.reshape((len(X), len(Y), len(Z))).reshape(-1, order='F')\r\n",
-                "        start = time.time()\r\n",
-                "        (v, f) = PyScaffolder.marching_cubes(Fxyz, grid_size=[len(X), len(Y), len(Z)], v_min=bounds[0], delta=step, clean=clean)\r\n",
-                "        if verbose:\r\n",
-                "            seconds = time.time() - start\r\n",
-                "            print('\\n%d triangles in %g seconds' % (len(points) // 3, seconds))\r\n",
-                "        # merge vertices and faces into points\r\n",
-                "        return v[f].reshape((-1, 3))\r\n",
-                "    except Exception as e:\r\n",
-                "        print(e)\r\n",
-                "        return np.array([])\r\n",
-                "\r\n",
-                "points = marching_cubes(f, step=0.01, verbose=True, clean=True)\r\n",
-                "write_binary_stl('out_2.stl', points)"
-            ],
+            "metadata": {},
             "outputs": [],
-            "metadata": {}
+            "source": [
+                "# Generate with PyScaffolder.marching_cubes\n",
+                "def marching_cubes(f, step=0.01, bounds=None, verbose=True, clean=True):\n",
+                "    from sdf.core import _estimate_bounds, _cartesian_product\n",
+                "    import time\n",
+                "\n",
+                "    if not bounds:\n",
+                "        bounds = _estimate_bounds(f)\n",
+                "    (x0, y0, z0), (x1, y1, z1) = bounds\n",
+                "    \n",
+                "    try:\n",
+                "        dx, dy, dz = step\n",
+                "    except TypeError:\n",
+                "        dx = dy = dz = step\n",
+                "    \n",
+                "    if verbose:\n",
+                "        print('min %g, %g, %g' % (x0, y0, z0))\n",
+                "        print('max %g, %g, %g' % (x1, y1, z1))\n",
+                "        print('step %g, %g, %g' % (dx, dy, dz))\n",
+                "\n",
+                "    X = np.arange(x0, x1, dx)\n",
+                "    Y = np.arange(y0, y1, dy)\n",
+                "    Z = np.arange(z0, z1, dz)\n",
+                "\n",
+                "    P = _cartesian_product(X, Y, Z)\n",
+                "    try:\n",
+                "        # Since the PyScaffolder marching_cubes aceept FREP: F(x,y,z) > 0\n",
+                "        # Then the negative of implicit function is used\n",
+                "        Fxyz = (-f(P))\n",
+                "        # Reshape to Fortran array (column-based) due to implementation of dualmc starting from z axis to x\n",
+                "        Fxyz = Fxyz.reshape((len(X), len(Y), len(Z))).reshape(-1, order='F')\n",
+                "        start = time.time()\n",
+                "        (v, f) = PyScaffolder.marching_cubes(Fxyz, grid_size=[len(X), len(Y), len(Z)], v_min=bounds[0], delta=step, clean=clean)\n",
+                "        if verbose:\n",
+                "            seconds = time.time() - start\n",
+                "            print('\\n%d triangles in %g seconds' % (len(points) // 3, seconds))\n",
+                "        # merge vertices and faces into points\n",
+                "        return v[f].reshape((-1, 3))\n",
+                "    except Exception as e:\n",
+                "        print(e)\n",
+                "        return np.array([])\n",
+                "\n",
+                "points = marching_cubes(f, step=0.01, verbose=True, clean=True)\n",
+                "write_binary_stl('out_2.stl', points)"
+            ]
         }
     ],
     "metadata": {
-        "orig_nbformat": 4,
+        "interpreter": {
+            "hash": "338d088b7365852483cbb7f745c4a9fbf18ad887a6ae80fcf58992043df108c7"
+        },
+        "kernelspec": {
+            "display_name": "Python 3.9.6 64-bit ('sdf': conda)",
+            "name": "python3"
+        },
         "language_info": {
-            "name": "python",
-            "version": "3.9.6",
-            "mimetype": "text/x-python",
             "codemirror_mode": {
                 "name": "ipython",
                 "version": 3
             },
-            "pygments_lexer": "ipython3",
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
             "nbconvert_exporter": "python",
-            "file_extension": ".py"
+            "pygments_lexer": "ipython3",
+            "version": "3.9.6"
         },
-        "kernelspec": {
-            "name": "python3",
-            "display_name": "Python 3.9.6 64-bit ('sdf': conda)"
-        },
-        "interpreter": {
-            "hash": "338d088b7365852483cbb7f745c4a9fbf18ad887a6ae80fcf58992043df108c7"
-        }
+        "orig_nbformat": 4
     },
     "nbformat": 4,
     "nbformat_minor": 2

--- a/docs/python.md
+++ b/docs/python.md
@@ -94,7 +94,7 @@ def slice_test(vertices, faces, k_slice=100, k_polygon=4, direction=0, callback=
 
 ## marching_cubes
 ```python
-def marching_cubes(f, grid_size=(100,100,100), v_min=(0,0,0), delta=0.01, clean=False, callback=None)
+def marching_cubes(f, grid_size=(100,100,100), v_min=(0,0,0), delta=0.01, clean=False)
 ```
 :   Slice input mesh into pore sizes
     ### Parameters

--- a/docs/python.md
+++ b/docs/python.md
@@ -103,7 +103,7 @@ def marching_cubes(f, grid_size=(100,100,100), v_min=(0,0,0), delta=0.01, clean=
     * `delta`: *Optional* array, list, tuple or double representing the dimension of a voxel
     * `v_min`: *Optional* array, list, tuple the coordinate of the corner of grid
     * `clean` *Optional* boolean that enable mesh cleaning after marching cubes
-    * `callback`: *Optional* function with one `integer` parameter indicating the progression
+    
     ###Return
     `#!python (v, f)` representing vertices and faces in `np.array`
 
@@ -120,8 +120,7 @@ def marching_cubes(f, grid_size=(100,100,100), v_min=(0,0,0), delta=0.01, clean=
         Fxyz,
         grid_size=4,
         delta=0.25,
-        v_min=(-.5, -.5, -.5),
-        callback = lambda x: print(x)
+        v_min=(-.5, -.5, -.5)
     )
     ```
 

--- a/docs/tutorial_2.md
+++ b/docs/tutorial_2.md
@@ -93,7 +93,7 @@ Then let's try `Pyscaffolder.marching_cubes` which implements `dual marching cub
 # Generate with PyScaffolder.marching_cubes
 
 def marching_cubes(f, step=0.01, bounds=None, verbose=True, clean=True):
-    from sdf.mesh import _estimate_bounds, _cartesian_product
+    from sdf.core import _estimate_bounds, _cartesian_product
     import time
 
     if not bounds:


### PR DESCRIPTION
- Use a recent `sdf` module; changing `sdf.mesh` to `sdf.core`
- Remove callback parameter from `PyScaffold::marching_cube`. Keeping It does not provide any value and adds extra blocking time for updating the progress ticks during `OpenMP` parallel execution.